### PR TITLE
chore: autoopen browser

### DIFF
--- a/moshi_mlx/moshi_mlx/local_web.py
+++ b/moshi_mlx/moshi_mlx/local_web.py
@@ -336,8 +336,9 @@ def web_server(client_to_server, server_to_client, args):
         await runner.setup()
         site = web.TCPSite(runner, args.host, args.port)
 
-        log("info", f"opening browser at http://{args.host}:{args.port}")
-        webbrowser.open(f"http://{args.host}:{args.port}")
+        if not args.no_browser:
+            log("info", f"opening browser at http://{args.host}:{args.port}")
+            webbrowser.open(f"http://{args.host}:{args.port}")
 
         await asyncio.gather(
             recv_loop(), send_loop(), recv_loop2(), send_loop2(), site.start()
@@ -361,6 +362,7 @@ def main():
     parser.add_argument("--static", type=str)
     parser.add_argument("--host", default="localhost", type=str)
     parser.add_argument("--port", default=8998, type=int)
+    parser.add_argument("--no-browser", action="store_true")
 
     args = parser.parse_args()
 


### PR DESCRIPTION
Grug may include the `s` and become confused, remove that possibility :) (particularly because the rust version is `https`)