### PR TITLE
Fix bugs in `scripts/moshi_benchmark.py`

### DIFF
--- a/moshi/moshi/models/loaders.py
+++ b/moshi/moshi/models/loaders.py
@@ -20,6 +20,9 @@ MOSHI_NAME = 'model.safetensors'
 MIMI_NAME = 'tokenizer-e351c8d8-checkpoint125.safetensors'
 DEFAULT_REPO = 'kyutai/moshiko-pytorch-bf16'
 
+TEXT_TOKENIZER_V0_1 = None
+MOSHIKO_V0_1 = None
+MIMI_V0_1 = None
 
 _seanet_kwargs = {
     "channels": 1,

--- a/scripts/moshi_benchmark.py
+++ b/scripts/moshi_benchmark.py
@@ -23,7 +23,7 @@ parser.add_argument("--moshi-weight", type=str, default=loaders.MOSHIKO_V0_1,
                     help="Name of the Moshi checkpoint in the given HF repo, or path to a local file.")
 parser.add_argument("--mimi-weight", type=str, default=loaders.MIMI_V0_1,
                     help="Name of the Mimi checkpoint in the given HF repo, or path to a local file.")
-parser.add_argument("--hf-repo", type=str, default=loaders.HF_REPO,
+parser.add_argument("--hf-repo", type=str, default=loaders.DEFAULT_REPO,
                     help="HF repo to look into, defaults to Kyutai's official one.")
 parser.add_argument("--steps", default=100, type=int)
 parser.add_argument("--profile", action="store_true")

--- a/scripts/moshi_benchmark.py
+++ b/scripts/moshi_benchmark.py
@@ -58,8 +58,6 @@ print("loading moshi")
 if args.moshi_weight is None:
     args.moshi_weight = hf_hub_download(args.hf_repo, loaders.MOSHI_NAME)
 lm = loaders.get_moshi_lm(args.moshi_weight, args.device)
-moshi_path = loaders.resolve_model_checkpoint(args.moshi_weight, args.hf_repo)
-lm = loaders.get_moshi_lm(moshi_path, args.device)
 lm_gen = LMGen(lm)
 print("lm loaded")
 


### PR DESCRIPTION
## Checklist

- [x] Read CONTRIBUTING.md, and accept the CLA by including the provided snippet. We will not accept PR without this.
- [x] Run pre-commit hook.
- [ ] If you changed Rust code, run `cargo check`, `cargo clippy`, `cargo test`.

## PR Description
In this PR, I fix two bugs when trying to run `scripts/moshi_benchmark.py` on GPU:
1.  The following constants are not defined in `models/loaders.py`: https://github.com/kyutai-labs/moshi/blob/main/scripts/moshi_benchmark.py#L20-L28. So I added these to `loaders.py` and initialized to `None` for now (assuming this was the intended behaviour).
2. There's a redundant line of code with an additional function call which is not defined anywhere (https://github.com/kyutai-labs/moshi/pull/64/files#diff-cb4c2a55b4bedd6211d2052ded75ff82133471651c2279651ff8de2bb31b303bL61-L62). So I have removed that.

After fixing these two bugs, the script runs successfully on my local cluster.

### CLA

I, @ishitamed19, confirm that I have read and understood the terms of the CLA of Kyutai-labs, as outlined in the repository's CONTRIBUTING.md, and I agree to be bound by these terms.
