### PR TITLE
added `moshi-*` scripts/entrypoints to pyproject.toml

### DIFF
--- a/moshi/pyproject.toml
+++ b/moshi/pyproject.toml
@@ -19,6 +19,10 @@ license = {text = "MIT"}
 dynamic = ["version"]
 readme = "README.md"
 
+[project.scripts]
+moshi-server = "moshi.server:main"
+moshi-client = "moshi.client:main"
+
 [tool.setuptools.dynamic]
 version = {attr = "moshi.__version__"}
 

--- a/moshi_mlx/moshi_mlx/local.py
+++ b/moshi_mlx/moshi_mlx/local.py
@@ -250,7 +250,7 @@ def client(printer_q, client_to_server, server_to_client, args):
         pass
 
 
-def main(printer: AnyPrinter):
+def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--tokenizer", type=str)
     parser.add_argument("--moshi-weight", type=str)
@@ -275,6 +275,12 @@ def main(printer: AnyPrinter):
     client_to_server = multiprocessing.Queue()
     server_to_client = multiprocessing.Queue()
     printer_q = multiprocessing.Queue()
+
+    printer: AnyPrinter
+    if sys.stdout.isatty():
+        printer = Printer()
+    else:
+        printer = RawPrinter()
 
     # Create two processes
     subprocess_args = printer_q, client_to_server, server_to_client, args
@@ -372,9 +378,4 @@ def main(printer: AnyPrinter):
 
 
 if __name__ == "__main__":
-    printer: AnyPrinter
-    if sys.stdout.isatty():
-        printer = Printer()
-    else:
-        printer = RawPrinter()
-    main(printer)
+    main()

--- a/moshi_mlx/pyproject.toml
+++ b/moshi_mlx/pyproject.toml
@@ -19,6 +19,9 @@ license = {text = "MIT"}
 dynamic = ["version"]
 readme = "README.md"
 
+[project.scripts]
+moshi-local = "moshi_mlx.local:main"
+moshi-local-web = "moshi_mlx.local_web:main"
 
 [build-system]
 requires = ["setuptools"]


### PR DESCRIPTION
## Checklist

- [x] Read CONTRIBUTING.md, and accept the CLA by including the provided snippet. We will not accept PR without this.
- [x] Run pre-commit hook.
- [x] If you changed Rust code, run `cargo check`, `cargo clippy`, `cargo test`.

## CLA

I, Erik Bjäreholt (@ErikBjare), confirm that I have read and understood the terms of the CLA of Kyutai-labs, as outlined in the repository's CONTRIBUTING.md, and I agree to be bound by these terms.

## PR Description

With this change you can now install moshi with:
 - `pipx install moshi` (once it's on PyPI)
 - `pipx install -e ./moshi/moshi` (which I tested)

This wasn't possible before since pipx requires a valid entrypoint to allow installation.