### PR TITLE
Increase max_seq_len for mimi-pyo3 and make it configurable.

### DIFF
--- a/rust/mimi-pyo3/Cargo.toml
+++ b/rust/mimi-pyo3/Cargo.toml
@@ -16,4 +16,4 @@ crate-type = ["cdylib"]
 anyhow = "1"
 numpy = "0.21.0"
 pyo3 = "0.21.0"
-moshi = { path = "../moshi-core", version = "0.2.1" }
+moshi = { path = "../moshi-core", version = "0.2.2" }

--- a/rust/moshi-backend/Cargo.toml
+++ b/rust/moshi-backend/Cargo.toml
@@ -26,7 +26,7 @@ rcgen = "0.13.1"
 http = "1.1.0"
 lazy_static = "1.5.0"
 log = "0.4.20"
-moshi = { path = "../moshi-core", version = "0.2.1" }
+moshi = { path = "../moshi-core", version = "0.2.2" }
 ogg = { version = "0.9.1", features = ["async"] }
 opus = "0.3.0"
 rand = { version = "0.8.5", features = ["getrandom"] }


### PR DESCRIPTION
## PR Description

Currently the max-seq-len for the mimi transformer in mimi-pyo3 was set to 4096 resulting in only ~2min30s of conversation. Bump this to a default of 8192 to reach 5 mins and make it configurable just in case.