### PR TITLE
Allow longer conversations with mlx.

### DIFF
--- a/moshi_mlx/moshi_mlx/local.py
+++ b/moshi_mlx/moshi_mlx/local.py
@@ -256,7 +256,7 @@ def main():
     parser.add_argument("--moshi-weight", type=str)
     parser.add_argument("--mimi-weight", type=str)
     parser.add_argument("-q", "--quantized", type=int, choices=[4, 8])
-    parser.add_argument("--steps", default=2500, type=int)
+    parser.add_argument("--steps", default=4000, type=int)
     parser.add_argument("--hf-repo", type=str, default=None)
 
     args = parser.parse_args()

--- a/moshi_mlx/moshi_mlx/local_web.py
+++ b/moshi_mlx/moshi_mlx/local_web.py
@@ -358,7 +358,7 @@ def main():
     parser.add_argument("--moshi-weight", type=str)
     parser.add_argument("--mimi-weight", type=str)
     parser.add_argument("-q", "--quantized", type=int, choices=[4, 8])
-    parser.add_argument("--steps", default=2500, type=int)
+    parser.add_argument("--steps", default=4000, type=int)
     parser.add_argument("--hf-repo", type=str)
     parser.add_argument("--static", type=str)
     parser.add_argument("--host", default="localhost", type=str)

--- a/moshi_mlx/pyproject.toml
+++ b/moshi_mlx/pyproject.toml
@@ -6,7 +6,7 @@ dependencies = [
     "numpy >= 2.1.0, < 2.2",
     "safetensors >= 0.4.0, < 0.5",
     "huggingface-hub >= 0.24, < 0.25",
-    "rustymimi == 0.1.1",
+    "rustymimi == 0.2.2",
     "sentencepiece == 0.2",
     "sounddevice == 0.5",
     "sphn >= 0.1.4",

--- a/moshi_mlx/requirements.txt
+++ b/moshi_mlx/requirements.txt
@@ -9,7 +9,7 @@ numpy==2.1.0
 psutil==6.0.0
 pycparser==2.22
 pyright==1.1.378
-rustymimi==0.1.1
+rustymimi==0.2.2
 safetensors==0.4.4
 sentencepiece==0.2.0
 six==1.16.0


### PR DESCRIPTION
## PR Description

Allow for longer sessions in moshi-mlx:
- Switch to rustymimi 0.2.2 where the max-seq-len is 8192 rather than 4096 allowing for 5min40s of conversations (as the mimi transformer runs at 25Hz).
- Set the default seq len to 4000 for the main generation routine.