### PR TITLE
Add an optional flag to use https on macos.

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -53,3 +53,8 @@ for http in such a case.
 To get around this, tunnel the 8998 port from the remote server to the localhost
 via ssh and access [localhost:8998](http://localhost:8998) via http normally
 after that.
+
+### How to get the key.pem and cert.pem files required for serving over https?
+```bash
+openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -days 365 -nodes -subj "/CN=localhost"
+```

--- a/moshi_mlx/moshi_mlx/local_web.py
+++ b/moshi_mlx/moshi_mlx/local_web.py
@@ -335,7 +335,15 @@ def web_server(client_to_server, server_to_client, args):
         log("info", f"listening to http://{args.host}:{args.port}")
         runner = web.AppRunner(app)
         await runner.setup()
-        site = web.TCPSite(runner, args.host, args.port)
+        ssl_context = None
+        if args.ssl is not None:
+            import ssl
+
+            ssl_context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
+            cert_file = os.path.join(args.ssl, "cert.pem")
+            key_file = os.path.join(args.ssl, "key.pem")
+            ssl_context.load_cert_chain(certfile=cert_file, keyfile=key_file)
+        site = web.TCPSite(runner, args.host, args.port, ssl_context=ssl_context)
 
         if not args.no_browser:
             log("info", f"opening browser at http://{args.host}:{args.port}")
@@ -363,6 +371,7 @@ def main():
     parser.add_argument("--static", type=str)
     parser.add_argument("--host", default="localhost", type=str)
     parser.add_argument("--port", default=8998, type=int)
+    parser.add_argument("--ssl", type=str, help="use https instead of http, this flag should point to a directory that contains valid key.pem and cert.pem files")
     parser.add_argument("--no-browser", action="store_true")
 
     args = parser.parse_args()

--- a/rust/README.md
+++ b/rust/README.md
@@ -29,6 +29,12 @@ maturin dev -r -m rust/mimi-pyo3/Cargo.toml
 
 ## Rust server
 
+If you don't have ssl certificates yet, generate a `key.pem` and `cert.pem` file
+using the following command.
+```bash
+openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -days 365 -nodes -subj "/CN=localhost"
+```
+
 In order to run the rust inference server, use the following command from within
 the this directory:
 


### PR DESCRIPTION
## PR Description

This makes it easier to run on remote boxes, e.g. for #106