### PR TITLE
Upgrade candle to 0.7.1.

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 license = "MIT/Apache-2.0"
 description = "moshi, a real-time voice AI"
@@ -18,10 +18,10 @@ categories = ["science"]
 
 
 [workspace.dependencies]
-candle = { version = "0.7.0", package = "candle-core" }
-candle-nn = "0.7.0"
-candle-transformers = "0.7.0"
-candle-flash-attn = "0.7.0"
+candle = { version = "0.7.1", package = "candle-core" }
+candle-nn = "0.7.1"
+candle-transformers = "0.7.1"
+candle-flash-attn = "0.7.1"
 
 [profile.release]
 debug = true

--- a/rust/mimi-pyo3/Cargo.toml
+++ b/rust/mimi-pyo3/Cargo.toml
@@ -16,4 +16,4 @@ crate-type = ["cdylib"]
 anyhow = "1"
 numpy = "0.21.0"
 pyo3 = "0.21.0"
-moshi = { path = "../moshi-core", version = "0.2.2" }
+moshi = { path = "../moshi-core", version = "0.2.3" }

--- a/rust/moshi-backend/Cargo.toml
+++ b/rust/moshi-backend/Cargo.toml
@@ -26,7 +26,7 @@ rcgen = "0.13.1"
 http = "1.1.0"
 lazy_static = "1.5.0"
 log = "0.4.20"
-moshi = { path = "../moshi-core", version = "0.2.2" }
+moshi = { path = "../moshi-core", version = "0.2.3" }
 ogg = { version = "0.9.1", features = ["async"] }
 opus = "0.3.0"
 rand = { version = "0.8.5", features = ["getrandom"] }


### PR DESCRIPTION
## PR Description

Upgrade candle to 0.7.1 so as to support cuda 12.6 and the new rotating kv cache.