### PR TITLE
Fix streaming propagate + fixing bug in KV Cache

### DIFF
--- a/moshi/moshi/__init__.py
+++ b/moshi/moshi/__init__.py
@@ -15,4 +15,4 @@ from . import modules
 from . import models
 from . import quantization
 
-__version__ = "0.1.0"
+__version__ = "0.1.1a1"

--- a/moshi/moshi/models/lm.py
+++ b/moshi/moshi/models/lm.py
@@ -465,6 +465,7 @@ class LMGen(StreamingModule[_LMGenState]):
         depformer_tokens: list[torch.Tensor] = []
         assert not lm_model.depformer.is_streaming
         with lm_model.depformer.streaming(B):
+            assert lm_model.depformer.is_streaming
             for cb_index in range(lm_model.dep_q):
                 input_ = prev_token[:, None, None]
                 logits = lm_model.forward_depformer(cb_index, input_, transformer_out)

--- a/moshi/moshi/models/lm.py
+++ b/moshi/moshi/models/lm.py
@@ -180,7 +180,9 @@ class LMModel(StreamingContainer):
             dtype=dtype,
             **kwargs_dep,
         )
-        self.depformer.set_streaming_propagate(False)
+        # Depformer follow its own cycle of streaming entirely contained in one time step
+        # and should not follow the streaming of the steps dimensions.
+        self.depformer.set_streaming_detached(True)
         dim = depformer_dim  # we will directly apply the next linears to the output of the Depformer.
 
         self.linears = nn.ModuleList(

--- a/moshi/moshi/modules/streaming.py
+++ b/moshi/moshi/modules/streaming.py
@@ -33,47 +33,42 @@ State = tp.TypeVar("State", bound=Resetable)
 class StreamingModule(abc.ABC, nn.Module, tp.Generic[State]):
     """Common API for streaming components.
 
-    Each streaming component has a streaming state, which is just a dict[str, Tensor].
-    By convention, the first dim of each tensor must be the batch size.
-    Don't use dots in the key names, as this would clash with submodules
-    (like in state_dict).
-
-    If `self._is_streaming` is True, the component should use and remember
-    the proper state inside `self._streaming_state`.
+    Each streaming component has a streaming state, `self._streaming_state`, which is None by default.
 
     To set a streaming component in streaming state, use
 
         with module.streaming():
             ...
 
-    This will automatically reset the streaming state when exiting the context manager.
+    This will automatically void the streaming state when exiting the context manager.
     This also automatically propagates to all streaming children module.
-
-    Some module might also implement the `StreamingModule.flush` method, although
-    this one is trickier, as all parents module must be StreamingModule and implement
-    it as well for it to work properly. See `StreamingSequential` after.
+    When the streaming state is set, modules should store whatever state they need in there.
     """
-
     def __init__(self) -> None:
         super().__init__()
         self._streaming_state: State | None = None
-        self._streaming_propagate: bool = True
+        self._streaming_detached: bool = False
 
     @property
     def is_streaming(self):
         return self._streaming_state is not None
 
-    def set_streaming_propagate(self, streaming_propagate: bool):
-        """If set to False, this module will not switch to streaming if a parent module
-        is set to streaming mode, only if directly set to streaming mode."""
-        self._streaming_propagate = streaming_propagate
+    def set_streaming_detached(self, streaming_detached: bool):
+        """If set to False, the default, this module and all submodules will switch to streaming mode
+        if a parent module is set to streaming mode.
+        If set to True, or in detach mode, only a direct call to this module `.streaming(...)` method
+        will set it into streaming mode, ignoring the changes from its parents.
+
+        This is useful is streaming over two different dimensions, e.g. for the RQ-Transformer
+        with the inner Depth Transformer working on the dimension of the codebooks."""
+        self._streaming_detached = streaming_detached
 
     def _apply_named_streaming(self, fn: tp.Any):
         def _handle_module(prefix: str, module: nn.Module):
             if isinstance(module, StreamingModule):
                 # If prefix is empty, we are the direct receiver of the streaming request,
-                # otherwise, we are inheriting from a parent and will stop if _streaming_propagate is False.
-                if not module._streaming_propagate and prefix != "":
+                # otherwise, we are inheriting from a parent and will stop if detached.
+                if module._streaming_detached and prefix != "":
                     return
                 fn(prefix, module)
             for name, child in module.named_children():

--- a/moshi/moshi/modules/streaming.py
+++ b/moshi/moshi/modules/streaming.py
@@ -64,11 +64,15 @@ class StreamingModule(abc.ABC, nn.Module, tp.Generic[State]):
         return self._streaming_state is not None
 
     def set_streaming_propagate(self, streaming_propagate: bool):
+        """If set to False, this module will not switch to streaming if a parent module
+        is set to streaming mode, only if directly set to streaming mode."""
         self._streaming_propagate = streaming_propagate
 
     def _apply_named_streaming(self, fn: tp.Any):
         def _handle_module(prefix: str, module: nn.Module):
             if isinstance(module, StreamingModule):
+                # If prefix is empty, we are the direct receiver of the streaming request,
+                # otherwise, we are inheriting from a parent and will stop if _streaming_propagate is False.
                 if not module._streaming_propagate and prefix != "":
                     return
                 fn(prefix, module)


### PR DESCRIPTION
## Checklist

- [x] Read CONTRIBUTING.md, and accept the CLA by including the provided snippet. We will not accept PR without this.
- [x] Run pre-commit hook.
- [ ] If you changed Rust code, run `cargo check`, `cargo clippy`, `cargo test`.

## PR Description

Depformer was never set in streaming mode which explain deterioration in quality in the CUDA demo (weights from first cb used all the way + no kv cache on previous cb...). Sorry about that, I'm quite surprised how it still somehow worked not so bad despite that pretty massive change.
Also fixing a bug in the KVCache, not as bad, would only have impact when wrapping around based on unit tests I ran on the internal codebase.

Update: after further review, the bug had no impact except if sin embeddings were to be used in the depformer which is not the case. This is because the original function was a mess and still properly put any children of Depformer in streaming mode even if Depformer itself was not streaming