### PR TITLE
Fix a potential issue in mlx import when importing pytorch safetensor model

### DIFF
--- a/scripts/import_mlx.py
+++ b/scripts/import_mlx.py
@@ -5,37 +5,43 @@
 import argparse
 import torch
 from pathlib import Path
-from safetensors.torch import save_file
-from moshi.models.loaders import get_moshi_lm
+from safetensors.torch import save_file, load_file
 
 
 def import_model(
     in_path: Path,
     out_path: Path,
     silent: bool = False,
-    is_pytorch_safetensors: bool = False,
+    max_out_n_q: int | None = None,
 ) -> None:
-    if is_pytorch_safetensors:
-        tch_model = get_moshi_lm(in_path).state_dict()
+    if in_path.suffix == ".safetensors":
+        tch_model = load_file(in_path)
     else:
         pkg = torch.load(in_path, map_location=torch.device("cpu"))
         tch_model = pkg["fsdp_best_state"]["model"]
 
-    n_q: int | None = None
+    in_n_q: int | None = None
     for idx in range(999):
         name = f"emb.{idx}.weight"
         if name not in tch_model:
-            n_q = idx
+            in_n_q = idx
             break
-    assert n_q is not None
+    out_n_q: int | None = None
+    for idx in range(999):
+        name = f"depformer_in.{idx}.weight"
+        if name not in tch_model:
+            out_n_q = idx
+            break
+    assert in_n_q is not None
+    assert out_n_q is not None
     if not silent:
-        print("Found n_q:", n_q)
+        print(f"in_n_q: {in_n_q}, out_n_q: {out_n_q}")
 
     model = {}
     for name in ["text_emb.weight", "text_linear.weight"]:
         model[name] = tch_model[name]
     model["out_norm.weight"] = tch_model["out_norm.alpha"][0, 0]
-    for idx in range(n_q):
+    for idx in range(in_n_q):
         src_name = f"emb.{idx}.weight"
         dst_name = f"audio_embs.{idx}.weight"
         model[dst_name] = tch_model[src_name]
@@ -51,10 +57,12 @@ def import_model(
             model[k] = v
 
     # Only export the first 8 slices of the depformer (main).
-    n_q_main = 8
-    print(f"only exporting the first {n_q_main}/{n_q} depformer layers")
-    chunk_n_q = n_q_main if is_pytorch_safetensors else n_q
-    for idx in range(n_q_main):
+    if max_out_n_q is not None:
+        exported_out_n_q = min(max_out_n_q, out_n_q)
+        print(f"only exporting the first {exported_out_n_q} depformer layers")
+    else:
+        exported_out_n_q = out_n_q
+    for idx in range(exported_out_n_q):
         base = f"depformer.slices.{idx}."
         model[base + "linear_in.weight"] = tch_model[f"depformer_in.{idx}.weight"]
         model[base + "linear_out.weight"] = tch_model[f"linears.{idx}.weight"]
@@ -68,12 +76,12 @@ def import_model(
             # WARNING: note that this uses in_proj_weight vs out_proj.weight
             model[layer + "self_attn.in_proj.weight"] = (
                 tch_model[f"depformer.layers.{layer_idx}.self_attn.in_proj_weight"]
-                .chunk(chunk_n_q)[idx]
+                .chunk(out_n_q)[idx]
                 .clone()
             )
             model[layer + "self_attn.out_proj.weight"] = (
                 tch_model[f"depformer.layers.{layer_idx}.self_attn.out_proj.weight"]
-                .chunk(chunk_n_q)[idx]
+                .chunk(out_n_q)[idx]
                 .clone()
             )
             model[layer + "norm1.weight"] = tch_model[
@@ -97,17 +105,21 @@ def main():
     parser.add_argument("checkpoint", type=str, help="the pytorch checkpoint to import")
     parser.add_argument("out", type=str, help="the mlx safetensors file to generate")
     parser.add_argument(
-        "-s", "--silent", action="store_true", help="Only prints the checkpoint name"
+        "-s", "--silent", action="store_true", help="only prints the checkpoint name"
     )
     parser.add_argument(
-        "-p", "--is_pytorch_safetensors", action="store_true", help="Import pytorch safetensors"
+        "--max-out-n-q",
+        type=int,
+        help="limit the number of depformer layers that are exported",
     )
     args = parser.parse_args()
 
     ckpt_path = Path(args.checkpoint)
     out_path = Path(args.out)
     if not out_path.exists():
-        import_model(ckpt_path, out_path, silent=args.silent, is_pytorch_safetensors=args.is_pytorch_safetensors)
+        import_model(
+            ckpt_path, out_path, silent=args.silent, max_out_n_q=args.max_out_n_q
+        )
     print(out_path)
 
 

--- a/scripts/import_mlx.py
+++ b/scripts/import_mlx.py
@@ -58,12 +58,12 @@ def import_model(in_path: Path, out_path: Path, silent: bool = False) -> None:
             # WARNING: note that this uses in_proj_weight vs out_proj.weight
             model[layer + "self_attn.in_proj.weight"] = (
                 tch_model[f"depformer.layers.{layer_idx}.self_attn.in_proj_weight"]
-                .chunk(n_q)[idx]
+                .chunk(n_q_main)[idx]
                 .clone()
             )
             model[layer + "self_attn.out_proj.weight"] = (
                 tch_model[f"depformer.layers.{layer_idx}.self_attn.out_proj.weight"]
-                .chunk(n_q)[idx]
+                .chunk(n_q_main)[idx]
                 .clone()
             )
             model[layer + "norm1.weight"] = tch_model[


### PR DESCRIPTION
## Checklist

- [x] Read CONTRIBUTING.md, and accept the CLA by including the provided snippet. We will not accept PR without this.
- [x] Run pre-commit hook.
- [x] If you changed Rust code, run `cargo check`, `cargo clippy`, `cargo test`.

## PR Description

<!-- Description for the PR -->

When converting the recently released Japanese version of Moshi at https://huggingface.co/nu-dialogue/j-moshi-ext to MLX, there was a tensor size mismatch error due to the converted model now using `n_q_main` for Depth transformer.

You can try out the MLX converted model with using this script by running `python -m moshi_mlx.local --hf-repo akkikiki/j-moshi-ext-mlx`.
