### PR TITLE
Fix crash in CPU-only environments by skipping torch.cuda.synchronize()

### DIFF
--- a/moshi/moshi/server.py
+++ b/moshi/moshi/server.py
@@ -70,7 +70,8 @@ class ServerState:
                 if tokens is None:
                     continue
                 _ = self.mimi.decode(tokens[:, 1:])
-        torch.cuda.synchronize()
+        if "cuda" in self.device.lower():
+            torch.cuda.synchronize()
 
     async def handle_chat(self, request):
         ws = web.WebSocketResponse()


### PR DESCRIPTION
## Checklist

- [x] Read CONTRIBUTING.md, and accept the CLA by including the provided snippet. We will not accept PR without this.
- [x] Run pre-commit hook.
- [x] If you changed Rust code, run `cargo check`, `cargo clippy`, `cargo test`.

## PR Description

<!-- Description for the PR -->

### Overview

This PR fixes a crash that occurs when running on CPU-only environments 
(e.g., `--device cpu` or no NVIDIA driver). 
Previously, `torch.cuda.synchronize()` was always called in `warmup()`, 
leading to an `AssertionError` on CPU builds.

### Changes

- In `server.py` → `warmup()`, the `torch.cuda.synchronize()` call is now 
  wrapped with a condition checking if `--device` contains `"cuda"`.

### Testing

- Confirmed no crash on a CPU-only setup (`pip install torch --index-url https://download.pytorch.org/whl/cpu`).
- GPU usage remains unaffected.

#### Actual command

I tested on Docker's debian:12.5-slim
```
pip install --upgrade pip --break-system-packages
pip install torch torchvision torchaudio --break-system-packages --index-url https://download.pytorch.org/whl/cpu
pip install moshi --break-system-packages
python3 -m moshi.server --device cpu
```

### CLA

I, rayfiyo, confirm that I have read and understood the terms of the CLA of Kyutai-labs, 
as outlined in the repository's CONTRIBUTING.md, and I agree to be bound by these terms.