### PR TITLE
Skip initial frame in Mimi

### DIFF
--- a/moshi/moshi/client.py
+++ b/moshi/moshi/client.py
@@ -162,7 +162,7 @@ async def run(printer: AnyPrinter, args):
             without_proto = args.url
         uri = f"{proto}://{without_proto}/api/chat"
 
-    printer.log("info", "Connecting to {uri}.")
+    printer.log("info", f"Connecting to {uri}.")
     async with aiohttp.ClientSession() as session:
         async with session.ws_connect(uri) as ws:
             printer.log("info", "connected!")


### PR DESCRIPTION
## Checklist

- [x ] Read CONTRIBUTING.md, and accept the CLA by including the provided snippet. We will not accept PR without this.
- [x ] Run pre-commit hook.
- [x ] If you changed Rust code, run `cargo check`, `cargo clippy`, `cargo test`.

## PR Description

The first frame from Mimi is ignored by the model, but could contain important patterns on which the model rely, due to the padding. This will reset the state of Mimi after the first frame. Not the cleanest but should do the job.
