### PR TITLE
Adding Q8 quantization with bitsandbytes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -182,3 +182,4 @@ laurent/cuda-test/check
 client/node_modules
 timings.json
 mlx-trace.json
+/scripts/token.txt

--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ We release three models:
 Depending on the backend, the file format and quantization available will vary. Here is the list
 of the HuggingFace repo with each model. Mimi is bundled in each of those, and always use the same checkpoint format.
 
-- Moshika for PyTorch (bf16): [kyutai/moshika-pytorch-bf16](https://huggingface.co/kyutai/moshika-pytorch-bf16).
-- Moshiko for PyTorch (bf16): [kyutai/moshiko-pytorch-bf16](https://huggingface.co/kyutai/moshiko-pytorch-bf16).
+- Moshika for PyTorch (bf16, int8): [kyutai/moshika-pytorch-bf16](https://huggingface.co/kyutai/moshika-pytorch-bf16), [kyutai/moshika-pytorch-q8](https://huggingface.co/kyutai/moshika-pytorch-q8) (experimental).
+- Moshiko for PyTorch (bf16, int8): [kyutai/moshiko-pytorch-bf16](https://huggingface.co/kyutai/moshiko-pytorch-bf16), [kyutai/moshiko-pytorch-q88888888](https://huggingface.co/kyutai/moshiko-pytorch-q8) (experimental).
 - Moshika for MLX (int4, int8, bf16): [kyutai/moshika-mlx-q4](https://huggingface.co/kyutai/moshika-mlx-q4), [kyutai/moshika-mlx-q8](https://huggingface.co/kyutai/moshika-mlx-q8),  [kyutai/moshika-mlx-bf16](https://huggingface.co/kyutai/moshika-mlx-bf16).
 - Moshiko for MLX (int4, int8, bf16): [kyutai/moshiko-mlx-q4](https://huggingface.co/kyutai/moshiko-mlx-q4), [kyutai/moshiko-mlx-q8](https://huggingface.co/kyutai/moshiko-mlx-q8),  [kyutai/moshiko-mlx-bf16](https://huggingface.co/kyutai/moshiko-mlx-bf16).
 - Moshika for Rust/Candle (int8, bf16): [kyutai/moshika-candle-q8](https://huggingface.co/kyutai/moshika-candle-q8),  [kyutai/moshika-mlx-bf16](https://huggingface.co/kyutai/moshika-candle-bf16).

--- a/moshi/moshi/__init__.py
+++ b/moshi/moshi/__init__.py
@@ -16,4 +16,4 @@ from . import modules
 from . import quantization
 from . import utils
 
-__version__ = "0.1.1a1"
+__version__ = "0.1.1a2"

--- a/moshi/moshi/models/lm.py
+++ b/moshi/moshi/models/lm.py
@@ -201,6 +201,7 @@ class LMModel(StreamingContainer):
         )
         self.condition_provider = condition_provider
         self.fuser = fuser
+        self.to(device=device, dtype=dtype)
         if quantize:
             quantize_transformer(self)
 

--- a/moshi/moshi/models/loaders.py
+++ b/moshi/moshi/models/loaders.py
@@ -163,11 +163,11 @@ def get_moshi_lm(filename: str | Path,
         device=device,
         dtype=dtype,
         quantize=quantize,
-        **lm_kwargs,
-    ).to(device=device, dtype=dtype)
+        **lm_kwargs)
     model.eval()
     if _is_safetensors(filename):
         load_model(model, filename, strict=strict)
+        pass
     else:
         pkg = torch.load(
             filename,

--- a/moshi/moshi/models/loaders.py
+++ b/moshi/moshi/models/loaders.py
@@ -14,6 +14,7 @@ from .lm import LMModel
 from ..modules import SEANetEncoder, SEANetDecoder, transformer
 from ..quantization import SplitResidualVectorQuantizer
 
+
 SAMPLE_RATE = 24000
 FRAME_RATE = 12.5
 
@@ -145,6 +146,7 @@ def get_mimi(filename: str | Path,
 def get_moshi_lm(filename: str | Path,
                  device: torch.device | str = 'cpu',
                  lm_kwargs: tp.Optional[tp.Dict] = None,
+                 quantize: bool | None = None,
                  strict: bool = True) -> LMModel:
     dtype = torch.bfloat16
     if lm_kwargs is None:
@@ -154,9 +156,12 @@ def get_moshi_lm(filename: str | Path,
         del lm_kwargs["conditioners"]
     if "fuser" in lm_kwargs:
         lm_kwargs["fuser"] = get_condition_fuser(lm_kwargs)
+    if quantize is None:
+        quantize = '.q8.' in str(filename)
     model = LMModel(
         device=device,
         dtype=dtype,
+        quantize=quantize,
         **lm_kwargs,
     ).to(device=device, dtype=dtype)
     model.eval()

--- a/moshi/moshi/models/loaders.py
+++ b/moshi/moshi/models/loaders.py
@@ -20,6 +20,7 @@ FRAME_RATE = 12.5
 
 TEXT_TOKENIZER_NAME = 'tokenizer_spm_32k_3.model'
 MOSHI_NAME = 'model.safetensors'
+MOSHI_Q8_NAME = 'model.q8.safetensors'
 MIMI_NAME = 'tokenizer-e351c8d8-checkpoint125.safetensors'
 DEFAULT_REPO = 'kyutai/moshiko-pytorch-bf16'
 

--- a/moshi/moshi/modules/gating.py
+++ b/moshi/moshi/modules/gating.py
@@ -48,6 +48,7 @@ class ActivationGating(nn.Module):
 
     def forward(self, x: torch.Tensor):
         if quantize.is_quantized(self.linear_in):
+            assert quantize.is_quantized(self.linear_out)
             x = quantize.linear(self.linear_in, x)
             B, T, _ = x.shape
             x = x.view(B, T, 2, -1)

--- a/moshi/moshi/modules/transformer.py
+++ b/moshi/moshi/modules/transformer.py
@@ -26,7 +26,7 @@ from .streaming import StreamingModule, StreamingContainer
 
 
 def quantize_transformer(module: torch.nn.Module):
-    for child in module.modules():
+    for name, child in module.named_modules():
         if isinstance(child, torch.nn.Linear):
             quantize.quantize_linear(child)
         elif isinstance(child, StreamingMultiheadAttention):

--- a/moshi/moshi/modules/transformer.py
+++ b/moshi/moshi/modules/transformer.py
@@ -654,6 +654,7 @@ class StreamingTransformer(StreamingModule[_TransformerState]):
             )
             if quantize:
                 # Quantizing layers one by one to avoid taking too much space during init.
+                self.layers[-1].to(device=device, dtype=dtype)
                 quantize_transformer(self.layers[-1])
 
     def _init_streaming_state(self, batch_size: int) -> _TransformerState:

--- a/moshi/moshi/run_inference.py
+++ b/moshi/moshi/run_inference.py
@@ -140,7 +140,11 @@ def main():
 
     log("info", "loading moshi")
     if args.moshi_weight is None:
-        args.moshi_weight = hf_hub_download(args.hf_repo, loaders.MOSHI_NAME)
+        if args.hf_repo.endswith('-q8'):
+            moshi_name = loaders.MOSHI_Q8_NAME
+        else:
+            moshi_name = loaders.MOSHI_NAME
+        args.moshi_weight = hf_hub_download(args.hf_repo, moshi_name)
     lm = loaders.get_moshi_lm(hf_get(args.moshi_weight), args.device, lm_kwargs=lm_kwargs)
     log("info", "moshi loaded")
 

--- a/moshi/moshi/server.py
+++ b/moshi/moshi/server.py
@@ -23,7 +23,6 @@ import torch
 
 
 from .client_utils import make_log
-from .modules.transformer import quantize_transformer
 from .models import loaders, MimiModel, LMModel, LMGen
 
 
@@ -179,7 +178,6 @@ def main():
     parser.add_argument("--tokenizer", type=str, help="Path to a local tokenizer file.")
     parser.add_argument("--moshi-weight", type=str, help="Path to a local checkpoint file for Moshi.")
     parser.add_argument("--mimi-weight", type=str, help="Path to a local checkpoint file for Mimi.")
-    parser.add_argument("--quantize", action="store_true", help="Run with int8 weight and activations.")
     parser.add_argument("--hf-repo", type=str, default=loaders.DEFAULT_REPO,
                         help="HF repo to look into, defaults Moshiko. "
                              "Use this to select a different pre-trained model.")
@@ -226,10 +224,6 @@ def main():
         args.moshi_weight = hf_hub_download(args.hf_repo, loaders.MOSHI_NAME)
     lm = loaders.get_moshi_lm(args.moshi_weight, args.device)
     log("info", "moshi loaded")
-    if args.quantize:
-        # This will quantize a bf16 model, and a noop if already loaded from q8.
-        quantize_transformer(lm)
-        log("info", "moshi quantizated")
 
     state = ServerState(mimi, text_tokenizer, lm, args.device)
     log("info", "warming up the model")

--- a/moshi/moshi/server.py
+++ b/moshi/moshi/server.py
@@ -221,7 +221,11 @@ def main():
 
     log("info", "loading moshi")
     if args.moshi_weight is None:
-        args.moshi_weight = hf_hub_download(args.hf_repo, loaders.MOSHI_NAME)
+        if args.hf_repo.endswith('-q8'):
+            moshi_name = loaders.MOSHI_Q8_NAME
+        else:
+            moshi_name = loaders.MOSHI_NAME
+        args.moshi_weight = hf_hub_download(args.hf_repo, moshi_name)
     lm = loaders.get_moshi_lm(args.moshi_weight, args.device)
     log("info", "moshi loaded")
 

--- a/moshi/moshi/server.py
+++ b/moshi/moshi/server.py
@@ -23,6 +23,7 @@ import torch
 
 
 from .client_utils import make_log
+from .modules.transformer import quantize_transformer
 from .models import loaders, MimiModel, LMModel, LMGen
 
 
@@ -178,6 +179,7 @@ def main():
     parser.add_argument("--tokenizer", type=str, help="Path to a local tokenizer file.")
     parser.add_argument("--moshi-weight", type=str, help="Path to a local checkpoint file for Moshi.")
     parser.add_argument("--mimi-weight", type=str, help="Path to a local checkpoint file for Mimi.")
+    parser.add_argument("--quantize", action="store_true", help="Run with int8 weight and activations.")
     parser.add_argument("--hf-repo", type=str, default=loaders.DEFAULT_REPO,
                         help="HF repo to look into, defaults Moshiko. "
                              "Use this to select a different pre-trained model.")
@@ -224,6 +226,10 @@ def main():
         args.moshi_weight = hf_hub_download(args.hf_repo, loaders.MOSHI_NAME)
     lm = loaders.get_moshi_lm(args.moshi_weight, args.device)
     log("info", "moshi loaded")
+    if args.quantize:
+        # This will quantize a bf16 model, and a noop if already loaded from q8.
+        quantize_transformer(lm)
+        log("info", "moshi quantizated")
 
     state = ServerState(mimi, text_tokenizer, lm, args.device)
     log("info", "warming up the model")

--- a/moshi/moshi/utils/quantize.py
+++ b/moshi/moshi/utils/quantize.py
@@ -1,3 +1,16 @@
+# Copyright (c) Kyutai, all rights reserved.
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Quantization based on bitsandbytes, supporting only 8 bits for now.
+We are taking from freedom from the intended use of bnb:
+
+- we are not replacing Linear with Linear8bitLt, but rely instead of the explicit use
+    of the `linear(module, x)` function.
+- for multi linears (e.g. per timestep weights in the Depth Transformer), we instead use the
+    `multi_linear` function.
+"""
+
 import bitsandbytes as bnb
 from bitsandbytes import functional as bnbF
 import torch

--- a/moshi/moshi/utils/quantize.py
+++ b/moshi/moshi/utils/quantize.py
@@ -25,7 +25,7 @@ def linear(module: nn.Module, x: torch.Tensor, name='weight') -> torch.Tensor:
         state.SCB = getattr(module, name + '_scb')
         assert isinstance(state.SCB, torch.Tensor)
         state.has_fp16_weights = False
-        y = bnb.matmul(x.half(), state.CB, state=state)
+        y = bnb.matmul(x.half().contiguous(), state.CB, state=state)
         assert isinstance(y, torch.Tensor)
         return y
     else:
@@ -69,7 +69,7 @@ def multi_linear(num_linear: int, module: nn.Module, x: torch.Tensor, offset: in
             state.CB = CB
             state.SCB = weight_scb[t + offset]
             state.has_fp16_weights = False
-            y = bnb.matmul(x[:, t].half(), CB, state=state)
+            y = bnb.matmul(x[:, t].half().contiguous(), CB, state=state)
             assert isinstance(y, torch.Tensor)
         ys.append(y)
     out = torch.stack(ys, 1)

--- a/moshi/moshi/utils/quantize.py
+++ b/moshi/moshi/utils/quantize.py
@@ -1,0 +1,81 @@
+import bitsandbytes as bnb
+from bitsandbytes import functional as bnbF
+import torch
+from torch import nn
+
+
+def linear(module: nn.Module, x: torch.Tensor, name='weight') -> torch.Tensor:
+    if is_quantized(module, name):
+        state = bnb.MatmulLtState()
+        state.CB = getattr(module, name)
+        assert isinstance(state.CB, torch.Tensor)
+        state.SCB = getattr(module, name + '_scb')
+        assert isinstance(state.SCB, torch.Tensor)
+        state.has_fp16_weights = False
+        y = bnb.matmul(x.half(), state.CB, state=state)
+        assert isinstance(y, torch.Tensor)
+        return y
+    else:
+        return nn.functional.linear(x, getattr(module, name))
+
+
+def multi_linear(num_linear: int, module: nn.Module, x: torch.Tensor, offset: int, name='weight') -> torch.Tensor:
+    """Utility to apply a multi linear layer to the given input. A multi linear layer
+    applies a different set of weight for each time step.
+
+    Args:
+        num_linear (int): Number of possible time steps and so number of linears.
+        weight (torch.Tensor): Weight tensor, with shape `[num_linear * chout, chin]`.
+        x (torch.Tensor): Input tensor, with shape `[B, T, C]`.
+        offset (int): offset for the current time step, in particular for decoding, with
+            time steps provided one by one.
+    """
+    B, T, C = x.shape
+    ys: list[torch.Tensor] = []
+    if is_quantized(module, name):
+        weight = getattr(module, name)
+        weight_scb = getattr(module, name + '_scb')
+    else:
+        weight = getattr(module, name)
+        weight_scb = None
+    assert isinstance(weight, torch.Tensor)
+
+    chout, chin = weight.shape
+    weight = weight.view(num_linear, -1, chin)
+    if weight_scb is not None:
+        assert isinstance(weight, torch.Tensor)
+        assert weight_scb.shape == (chout,), (weight_scb, chout)
+        weight_scb = weight_scb.view(num_linear, -1)
+
+    for t in range(T):
+        if weight_scb is None:
+            y = nn.functional.linear(x[:, t], weight[t + offset])
+        else:
+            state = bnb.MatmulLtState()
+            CB = weight[t + offset]
+            state.CB = CB
+            state.SCB = weight_scb[t + offset]
+            state.has_fp16_weights = False
+            y = bnb.matmul(x[:, t].half(), CB, state=state)
+            assert isinstance(y, torch.Tensor)
+        ys.append(y)
+    out = torch.stack(ys, 1)
+    return out
+
+
+def is_quantized(module: nn.Module, name: str = 'weight'):
+    return hasattr(module, name + '_scb')
+
+
+def quantize_param(module: nn.Module, name: str = 'weight') -> None:
+    if is_quantized(module, name):
+        return
+    weight = getattr(module, name)
+    CB, SCB, _ = bnbF.int8_vectorwise_quant(weight.data.to(torch.float16))
+    setattr(module, name, nn.Parameter(CB, requires_grad=False))
+    setattr(module, name + '_scb', nn.Parameter(SCB, requires_grad=False))
+
+
+def quantize_linear(linear: nn.Module) -> None:
+    assert linear.bias is None
+    quantize_param(linear)

--- a/moshi/pyproject.toml
+++ b/moshi/pyproject.toml
@@ -6,6 +6,7 @@ dependencies = [
     "numpy >= 1.26, < 2.2",
     "safetensors >= 0.4.0, < 0.5",
     "huggingface-hub >= 0.24, < 0.25",
+    "bitsandbytes >= 0.45",
     "einops == 0.7",
     "sentencepiece == 0.2",
     "sounddevice == 0.5",

--- a/moshi/pyproject.toml
+++ b/moshi/pyproject.toml
@@ -6,7 +6,7 @@ dependencies = [
     "numpy >= 1.26, < 2.2",
     "safetensors >= 0.4.0, < 0.5",
     "huggingface-hub >= 0.24, < 0.25",
-    "bitsandbytes >= 0.45 < 0.46",
+    "bitsandbytes >= 0.45, < 0.46",
     "einops == 0.7",
     "sentencepiece == 0.2",
     "sounddevice == 0.5",

--- a/moshi/pyproject.toml
+++ b/moshi/pyproject.toml
@@ -6,7 +6,7 @@ dependencies = [
     "numpy >= 1.26, < 2.2",
     "safetensors >= 0.4.0, < 0.5",
     "huggingface-hub >= 0.24, < 0.25",
-    "bitsandbytes >= 0.45",
+    "bitsandbytes >= 0.45 < 0.46",
     "einops == 0.7",
     "sentencepiece == 0.2",
     "sounddevice == 0.5",

--- a/scripts/export_quantized.py
+++ b/scripts/export_quantized.py
@@ -1,0 +1,53 @@
+import argparse
+from pathlib import Path
+import tempfile
+
+from huggingface_hub import HfApi, hf_hub_download
+from safetensors.torch import save_file
+
+from moshi.models import loaders
+from moshi.modules.transformer import quantize_transformer
+
+def main():
+    parser = argparse.ArgumentParser('export_quantized')
+    parser.add_argument('moshi_repo')
+
+    args = parser.parse_args()
+
+    token = open('token.txt').read().strip()
+    api = HfApi(token=token)
+    repo = args.moshi_repo
+    new_repo = repo.rsplit('-', 1)[0] + '-q8-tmp'
+    if not api.repo_exists(new_repo):
+        api.create_repo(new_repo, repo_type='model')
+        print("Repo created.")
+
+    to_copy = ['README.md', 'tokenizer-e351c8d8-checkpoint125.safetensors', 'tokenizer_spm_32k_3.model']
+    for file in to_copy:
+        if not api.file_exists(new_repo, file):
+            print("File", file, "is missing")
+            old_file = hf_hub_download(repo, file)
+            api.upload_file(
+                path_or_fileobj=old_file,
+                path_in_repo=file,
+                repo_id=new_repo,
+                repo_type="model")
+    print("Downloading base model.")
+    ckpt = hf_hub_download(repo, loaders.MOSHI_NAME)
+    print("Creating model.")
+    model = loaders.get_moshi_lm(ckpt, device='cuda')
+    print("Quantizing model.")
+    quantize_transformer(model)
+    with tempfile.NamedTemporaryFile(suffix='.safetensors', delete=True) as file:
+        save_file(model.state_dict(), file.name)
+        size = Path(file.name).stat().st_size / 1e9
+        print(f"Checkpoint size: {size:.1f}GB")
+        api.upload_file(
+            path_or_fileobj=file.name,
+            path_in_repo='model.q8.safetensors',
+            repo_id=new_repo,
+            repo_type="model")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/export_quantized.py
+++ b/scripts/export_quantized.py
@@ -1,3 +1,9 @@
+# Copyright (c) Kyutai, all rights reserved.
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+"""Convert a repo into a quantized one (PyTorch only). Need to run from a GPU."""
+
+
 import argparse
 from pathlib import Path
 import tempfile
@@ -17,7 +23,7 @@ def main():
     token = open('token.txt').read().strip()
     api = HfApi(token=token)
     repo = args.moshi_repo
-    new_repo = repo.rsplit('-', 1)[0] + '-q8-tmp'
+    new_repo = repo.rsplit('-', 1)[0] + '-q8'
     if not api.repo_exists(new_repo):
         api.create_repo(new_repo, repo_type='model')
         print("Repo created.")


### PR DESCRIPTION
## Checklist

- [x ] Read CONTRIBUTING.md, and accept the CLA by including the provided snippet. We will not accept PR without this.
- [ x] Run pre-commit hook.
- [x ] If you changed Rust code, run `cargo check`, `cargo clippy`, `cargo test`.

## PR Description
Adding Moshi q8 with bitsandbytes, not clear if there is no loss of IQ in the model, but it runs.