### PR TITLE
Lazy bnb import as it is not available in OSX

### DIFF
--- a/moshi/moshi/utils/quantize.py
+++ b/moshi/moshi/utils/quantize.py
@@ -11,13 +11,12 @@ We are taking from freedom from the intended use of bnb:
     `multi_linear` function.
 """
 
-import bitsandbytes as bnb
-from bitsandbytes import functional as bnbF
 import torch
 from torch import nn
 
 
 def linear(module: nn.Module, x: torch.Tensor, name='weight') -> torch.Tensor:
+    import bitsandbytes as bnb  # type: ignore
     if is_quantized(module, name):
         state = bnb.MatmulLtState()
         state.CB = getattr(module, name)
@@ -44,6 +43,7 @@ def multi_linear(num_linear: int, module: nn.Module, x: torch.Tensor, offset: in
         offset (int): offset for the current time step, in particular for decoding, with
             time steps provided one by one.
     """
+    import bitsandbytes as bnb  # type: ignore
     B, T, C = x.shape
     ys: list[torch.Tensor] = []
     if is_quantized(module, name):
@@ -83,6 +83,7 @@ def is_quantized(module: nn.Module, name: str = 'weight'):
 
 
 def quantize_param(module: nn.Module, name: str = 'weight') -> None:
+    from bitsandbytes import functional as bnbF  # type: ignore
     if is_quantized(module, name):
         # Due to model casting, the type of SCB might be wrong, althought
         # that would only happen during the init. Let's recast it to float.

--- a/moshi/pyproject.toml
+++ b/moshi/pyproject.toml
@@ -6,7 +6,7 @@ dependencies = [
     "numpy >= 1.26, < 2.2",
     "safetensors >= 0.4.0, < 0.5",
     "huggingface-hub >= 0.24, < 0.25",
-    "bitsandbytes >= 0.45, < 0.46",
+    "bitsandbytes >= 0.45, < 0.46; sys_platform == 'linux'",
     "einops == 0.7",
     "sentencepiece == 0.2",
     "sounddevice == 0.5",


### PR DESCRIPTION
## Checklist

- [x ] Read CONTRIBUTING.md, and accept the CLA by including the provided snippet. We will not accept PR without this.
- [x ] Run pre-commit hook.
- [ x] If you changed Rust code, run `cargo check`, `cargo clippy`, `cargo test`.

## PR Description

bnb is not available on OSX (or at least juste a really old version with all the symbols missing), so making bnb only required on linux.