### PR TITLE
Various MLX tweaks.

### DIFF
--- a/moshi_mlx/moshi_mlx/__init__.py
+++ b/moshi_mlx/moshi_mlx/__init__.py
@@ -9,4 +9,4 @@ moshi_mlx is the MLX inference codebase for Kyutai audio generation models.
 
 from . import modules, models, utils
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/moshi_mlx/moshi_mlx/run_inference.py
+++ b/moshi_mlx/moshi_mlx/run_inference.py
@@ -110,7 +110,7 @@ def main():
         cfg_coef=args.cfg_coef,
         check=False,
     )
-    generated_codebooks = lm_config.generated_codebooks()
+    generated_codebooks = lm_config.generated_codebooks
 
     all_out_pcm = []
     start_time = time.time()

--- a/moshi_mlx/pyproject.toml
+++ b/moshi_mlx/pyproject.toml
@@ -6,11 +6,11 @@ dependencies = [
     "numpy >= 2.1.0, < 2.2",
     "safetensors >= 0.4.0, < 0.5",
     "huggingface-hub >= 0.24, < 0.25",
-    "rustymimi == 0.2.2",
+    "rustymimi == 0.4.0",
     "sentencepiece == 0.2",
     "sounddevice == 0.5",
     "sphn >= 0.1.4",
-    "mlx >= 0.17.2, < 0.18",
+    "mlx >= 0.22.0, < 0.23",
     "aiohttp>=3.10.5, <3.11",
 ]
 authors = [{name="Laurent Mazaré", email="laurent@kyutai.org"}]

--- a/moshi_mlx/requirements.txt
+++ b/moshi_mlx/requirements.txt
@@ -3,13 +3,13 @@ blessed==1.20.0
 cffi==1.17.0
 dashing==0.1.0
 huggingface-hub==0.24.6
-mlx==0.17.2
+mlx==0.22.0
 nodeenv==1.9.1
 numpy==2.1.0
 psutil==6.0.0
 pycparser==2.22
 pyright==1.1.378
-rustymimi==0.2.2
+rustymimi==0.4.0
 safetensors==0.4.4
 sentencepiece==0.2.0
 six==1.16.0


### PR DESCRIPTION
- Bump the version number.
- Avoid the buggy teacher forcing.
- Add some properties to get the number of generated/other audio codebooks.
- Update the mlx version.