### PR TITLE
Update server.py

### DIFF
--- a/moshi/moshi/server.py
+++ b/moshi/moshi/server.py
@@ -277,7 +277,7 @@ def main():
         tunnel = setup_tunnel('localhost', args.port, tunnel_token, None)
         log("info", f"Tunnel started, if executing on a remote GPU, you can use {tunnel}.")
         log("info", "Note that this tunnel goes through the US and you might experience high latency in Europe.")
-    web.run_app(app, port=args.port, ssl_context=ssl_context)
+    web.run_app(app, host=args.host , port=args.port, ssl_context=ssl_context)
 
 
 with torch.no_grad():


### PR DESCRIPTION
## Checklist

I, adfr, hereby grant to Kyutai-labs a perpetual, worldwide, non-exclusive, royalty-free, irrevocable license to use, modify, distribute, and sublicense my Contributions.

I understand and accept that Contributions are limited to modifications, improvements, or changes to the project’s source code submitted via pull requests. I accept that Kyutai-labs has full discretion to review, accept, reject, or request changes to any Contributions I submit, and that submitting a pull request does not guarantee its inclusion in the project.

By submitting a Contribution, I grant Kyutai-labs a perpetual, worldwide license to use, modify, reproduce, distribute, and create derivative works based on my Contributions. I also agree to assign all patent rights for any inventions or improvements that arise from my Contributions, giving the Kyutai-labs full rights to file for and enforce patents. I understand that the Kyutai-labs may commercialize, relicense, or exploit the project and my Contributions without further notice or obligation to me. I confirm that my Contributions are original and that I have the legal right to grant this license. If my Contributions include third-party materials, I will ensure that I have the necessary permissions and will disclose this information. I accept that once my Contributions are integrated, they may be altered or removed at the Kyutai-labs’s discretion.

I acknowledge that I am making these Contributions voluntarily and will not receive any compensation. Furthermore, I understand that all Contributions, including mine, are provided on an "as-is" basis, with no warranties. By submitting a pull request, I agree to be bound by these terms.

- [x] Read CONTRIBUTING.md, and accept the CLA by including the provided snippet. We will not accept PR without this.
- [x] Run pre-commit hook.
- [x] If you changed Rust code, run `cargo check`, `cargo clippy`, `cargo test`.

## PR Description

Host is not passed to run_app. This is not a problem when running locally but on some remote development platform when host is no 0.0.0.0 the app will fail. Therefore, I pass the host to the webapp.
