### PR TITLE
executation masks

### DIFF
--- a/moshi/moshi/__init__.py
+++ b/moshi/moshi/__init__.py
@@ -16,4 +16,4 @@ from . import modules
 from . import quantization
 from . import utils
 
-__version__ = "0.2.4a1"
+__version__ = "0.2.5a1"

--- a/moshi/moshi/models/compression.py
+++ b/moshi/moshi/models/compression.py
@@ -225,7 +225,7 @@ class MimiModel(CompressionModel[_MimiState]):
             graphed_tr_enc = CUDAGraphed(self.encoder_transformer, disable=disable)
         if self.decoder_transformer is not None:
             graphed_tr_dec = CUDAGraphed(self.decoder_transformer, disable=disable)
-        return _MimiState(graphed_tr_enc, graphed_tr_dec)
+        return _MimiState(batch_size, device, graphed_tr_enc, graphed_tr_dec)
 
     @property
     def channels(self) -> int:

--- a/moshi/moshi/models/lm.py
+++ b/moshi/moshi/models/lm.py
@@ -458,7 +458,6 @@ class LMModel(StreamingContainer):
 
 @dataclass
 class _LMGenState(State):
-    batch_size: int
     cache: torch.Tensor
     initial: torch.Tensor
     graphed_main: CUDAGraphed
@@ -538,7 +537,7 @@ class LMGen(StreamingModule[_LMGenState]):
         graphed_depth = CUDAGraphed(self.depformer_step, disable=disable)
 
         state = _LMGenState(
-            batch_size, cache, initial, graphed_main, graphed_depth,
+            batch_size, lm_model.device, cache, initial, graphed_main, graphed_depth,
             condition_sum=condition_sum)
 
         if self.cfg_coef != 1.:

--- a/moshi/moshi/modules/rope.py
+++ b/moshi/moshi/modules/rope.py
@@ -36,11 +36,11 @@ def apply_rope(
 
     ds = torch.arange(D // 2, device=q.device, dtype=torch.float32)
     freqs = torch.exp(ds * (-math.log(max_period) * 2 / D))
-    ts = offset.float() + torch.arange(T, device=q.device, dtype=torch.float32)
+    ts = offset.float().view(-1, 1) + torch.arange(T, device=q.device, dtype=torch.float32)
     if time_before_heads:
-        ts = ts.view(-1, 1, 1)
+        ts = ts.view(B, -1, 1, 1)
     else:
-        ts = ts.view(1, -1, 1)
+        ts = ts.view(B, 1, -1, 1)
 
     dims = q.shape[:-1]
     q = q.view(*dims, D // 2, 2)

--- a/moshi/moshi/modules/seanet.py
+++ b/moshi/moshi/modules/seanet.py
@@ -14,7 +14,7 @@ import numpy as np
 import torch.nn as nn
 
 from .conv import StreamingConv1d, StreamingConvTranspose1d
-from .streaming import StreamingContainer, StreamingAdd
+from .streaming import StreamingContainer
 from ..utils.compile import torch_compile_lazy
 
 
@@ -74,7 +74,6 @@ class SEANetResnetBlock(StreamingContainer):
                 ),
             ]
         self.block = nn.Sequential(*block)
-        self.add = StreamingAdd()
         self.shortcut: nn.Module
         if true_skip:
             self.shortcut = nn.Identity()
@@ -90,8 +89,10 @@ class SEANetResnetBlock(StreamingContainer):
             )
 
     def forward(self, x):
+        return x
         u, v = self.shortcut(x), self.block(x)
-        return self.add(u, v)
+        assert u.shape == v.shape, (u.shape, v.shape, x.shape)
+        return u + v
 
 
 class SEANetEncoder(StreamingContainer):

--- a/moshi/moshi/modules/seanet.py
+++ b/moshi/moshi/modules/seanet.py
@@ -15,7 +15,6 @@ import torch.nn as nn
 
 from .conv import StreamingConv1d, StreamingConvTranspose1d
 from .streaming import StreamingContainer
-from ..utils.compile import torch_compile_lazy
 
 
 class SEANetResnetBlock(StreamingContainer):
@@ -89,7 +88,6 @@ class SEANetResnetBlock(StreamingContainer):
             )
 
     def forward(self, x):
-        return x
         u, v = self.shortcut(x), self.block(x)
         assert u.shape == v.shape, (u.shape, v.shape, x.shape)
         return u + v
@@ -237,7 +235,6 @@ class SEANetEncoder(StreamingContainer):
 
         self.model = nn.Sequential(*model)
 
-    @torch_compile_lazy
     def forward(self, x):
         return self.model(x)
 
@@ -390,7 +387,6 @@ class SEANetDecoder(StreamingContainer):
             model += [final_act(**final_activation_params)]
         self.model = nn.Sequential(*model)
 
-    @torch_compile_lazy
     def forward(self, z):
         y = self.model(z)
         return y

--- a/moshi/moshi/modules/streaming.py
+++ b/moshi/moshi/modules/streaming.py
@@ -15,18 +15,23 @@ Streaming module API that should be implemented by all Streaming components,
 import abc
 from contextlib import ExitStack
 from dataclasses import dataclass
-import itertools
-import math
 import typing as tp
 from torch import nn
 import torch
 
 
-class State:
+@dataclass
+class State(abc.ABC):
     """Base State for streaming, requires to be resetable and also support the context
     protocol. The state will be entered when """
+    batch_size: int
+    device: torch.device
+
+    def __post_init__(self):
+        self.exec_mask = torch.ones(self.batch_size, device=self.device, dtype=torch.bool)
+
     def reset(self) -> None:
-        pass
+        self.exec_mask.fill_(True)
 
     def __enter__(self) -> None:
         pass
@@ -155,206 +160,18 @@ class StreamingModule(abc.ABC, nn.Module, tp.Generic[StateT]):
         if state:
             raise RuntimeError(f"Some states were not consumed: {list(state.keys())}")
 
+    def set_exec_mask(self, exec_mask: torch.Tensor):
+        def _set_exec_mask(name: str, module: StreamingModule):
+            nonlocal exec_mask
+            state = module._streaming_state
+            assert state is not None
+            exec_mask = exec_mask.to(state.exec_mask)
+            state.exec_mask[:] = exec_mask
+
+        self._apply_named_streaming(_set_exec_mask)
+
 
 class StreamingContainer(StreamingModule[State]):
     def _init_streaming_state(self, batch_size: int) -> State:
-        return State()
-
-
-@dataclass
-class _StreamingAddState(State):
-    previous_x: torch.Tensor | None = None
-    previous_y: torch.Tensor | None = None
-
-    def reset(self):
-        self.previous_x = None
-        self.previous_y = None
-
-
-class StreamingAdd(StreamingModule[_StreamingAddState]):
-    def _init_streaming_state(self, batch_size: int) -> _StreamingAddState:
-        return _StreamingAddState()
-
-    def forward(self, x: torch.Tensor, y: torch.Tensor):
-        if self._streaming_state is None:
-            return x + y
-        else:
-            prev_x = self._streaming_state.previous_x
-            prev_y = self._streaming_state.previous_y
-            if prev_x is not None:
-                x = torch.cat([prev_x, x], dim=-1)
-            if prev_y is not None:
-                y = torch.cat([prev_y, y], dim=-1)
-            m_l = min(x.shape[-1], y.shape[-1])
-            self._streaming_state.previous_x = x[..., m_l:]
-            self._streaming_state.previous_y = y[..., m_l:]
-            return x[..., :m_l] + y[..., :m_l]
-
-
-@dataclass
-class _StreamingConvState(State):
-    previous: torch.Tensor | None = None
-
-    def reset(self):
-        self.previous = None
-
-
-class RawStreamingConv1d(nn.Conv1d, StreamingModule[_StreamingConvState]):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        assert self.padding[0] == 0, "Padding should be handled outside."
-        assert (
-            self.stride[0] <= self.kernel_size[0]
-        ), "stride must be less than kernel_size."
-
-    def _init_streaming_state(self, batch_size: int) -> _StreamingConvState:
-        return _StreamingConvState()
-
-    def forward(self, input: torch.Tensor) -> torch.Tensor:
-        stride = self.stride[0]
-        # Effective kernel size accounting for dilation.
-        kernel = (self.kernel_size[0] - 1) * self.dilation[0] + 1
-        if self._streaming_state is None:
-            return super().forward(input)
-        else:
-            # Due to the potential overlap, we might have some cache of the previous time steps.
-            previous = self._streaming_state.previous
-            if previous is not None:
-                input = torch.cat([previous, input], dim=-1)
-            B, C, T = input.shape
-            # We now compute the number of full convolution frames, i.e. the frames
-            # that are ready to be computed.
-            num_frames = max(0, int(math.floor((T - kernel) / stride) + 1))
-            offset = num_frames * stride
-            # We will compute `num_frames` outputs, and we are advancing by `stride`
-            # for each of the frame, so we know the data before `stride * num_frames`
-            # will never be used again.
-            self._streaming_state.previous = input[..., offset:]
-            if num_frames > 0:
-                input_length = (num_frames - 1) * stride + kernel
-                out = super().forward(input[..., :input_length])
-            else:
-                # Not enough data as this point to output some new frames.
-                out = torch.empty(
-                    B, self.out_channels, 0, device=input.device, dtype=input.dtype
-                )
-            return out
-
-
-@dataclass
-class _StreamingConvTrState(State):
-    partial: torch.Tensor | None = None
-
-    def reset(self):
-        self.partial = None
-
-
-class RawStreamingConvTranspose1d(
-    nn.ConvTranspose1d, StreamingModule[_StreamingConvTrState]
-):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        assert self.padding[0] == 0, "Padding should be handled outside."
-        assert self.dilation[0] == 1, "No dilation for now"
-        assert (
-            self.stride[0] <= self.kernel_size[0]
-        ), "stride must be less than kernel_size."
-        assert self.output_padding[0] == 0, "Output padding not supported."
-
-    def _init_streaming_state(self, batch_size: int) -> _StreamingConvTrState:
-        return _StreamingConvTrState()
-
-    def forward(self, x: torch.Tensor) -> torch.Tensor:  # type: ignore
-        B, C, T = x.shape
-        stride = self.stride[0]
-        kernel = self.kernel_size[0]
-        if self._streaming_state is None:
-            return super().forward(x)
-        else:
-            if T == 0:
-                return torch.empty(
-                    B, self.out_channels, 0, device=x.device, dtype=x.dtype
-                )
-            out = super().forward(x)
-            OT = out.shape[-1]
-            partial = self._streaming_state.partial
-            if partial is not None:
-                # Due to the potential overlap, the rightmost output of the conv transpose is not
-                # ready to be output, as it will receive contributions from the next input frames.
-                # Here we recover those `partial` output frames. We know that the first time step
-                # of the `partial` tensor corresponds to the first time step of `out` as anything
-                # coming before the first time step of `out` would have been already flushed.
-                PT = partial.shape[-1]
-                if self.bias is not None:
-                    out[..., :PT] += partial - self.bias[:, None]
-                else:
-                    out[..., :PT] += partial
-            # The input is T, the output is S * (T - 1) + K.
-            # The offset of the left of the next frame will be S * T
-            # so everything between 0 and S * T is ready to be output, and we need
-            # to keep in the internal state everything beyond that, i.e. S (T - 1) + K - S T = K - S
-            invalid_steps = kernel - stride
-            partial = out[..., OT - invalid_steps :]
-            out = out[..., : OT - invalid_steps]
-            self._streaming_state.partial = partial
-            return out
-
-
-def test():
-    torch.manual_seed(1234)
-    device = "cpu"
-    if torch.cuda.is_available():
-        # Avoid the cuda optimizations that would take place on single precision
-        # floats for convolutions.
-        torch.backends.cudnn.enabled = True
-        torch.backends.cudnn.benchmark = False
-        torch.backends.cudnn.deterministic = True
-        torch.backends.cuda.matmul.allow_tf32 = False
-        torch.backends.cudnn.allow_tf32 = False
-        device = "cuda:0"
-
-    kernel_sizes = [1, 3, 4, 8, 15, 16]
-    strides = [1, 2, 3, 4, 5, 6, 7, 8, 9]
-    chin = 6
-    chout = 12
-
-    for kernel, stride in itertools.product(kernel_sizes, strides):
-        if stride > kernel:
-            continue
-        conv = RawStreamingConv1d(chin, chout, kernel, stride).to(device)
-        convtr = RawStreamingConvTranspose1d(chout, chin, kernel, stride).to(device)
-
-        for length in [4, 8, 32, 54, 65, 128, 1043]:
-            print(f"ksize {kernel} strides {stride} len {length}")
-            if length < kernel:
-                continue
-            batch_size = 3
-            x = torch.randn(batch_size, chin, length).to(device)
-            y = conv(x)
-            z = convtr(y)
-            for chunk_size in [1, 3, 5, 8]:
-                ys = []
-                zs = []
-                with conv.streaming(batch_size), convtr.streaming(batch_size):
-                    for offset in range(0, length, chunk_size):
-                        chunk = x[..., offset : offset + chunk_size]
-                        ys.append(conv(chunk))
-                        zs.append(convtr(ys[-1]))
-                y_stream = torch.cat(ys, dim=-1)
-                z_stream = torch.cat(zs, dim=-1)
-                y = y[..., : y_stream.shape[-1]]
-                z = z[..., : z_stream.shape[-1]]
-                assert y.shape == y_stream.shape, (y.shape, y_stream.shape)
-                delta = (y_stream - y).norm() / y.norm()
-                assert delta <= 1e-6, delta
-                num_frames = int((length - kernel) / stride) + 1
-                assert num_frames == y_stream.shape[-1]
-
-                assert z.shape == z_stream.shape, (z.shape, z_stream.shape)
-                delta = (z_stream - z).norm() / z.norm()
-                assert delta <= 1e-6, (delta, (z_stream - z).abs().mean(dim=(0, 1)))
-
-
-if __name__ == "__main__":
-    with torch.no_grad():
-        test()
+        device = next(iter(self.parameters())).device
+        return State(batch_size, device)

--- a/moshi/moshi/utils/compile.py
+++ b/moshi/moshi/utils/compile.py
@@ -243,6 +243,9 @@ class CUDAGraphed:
                     if source.shape != target.shape:
                         raise ValueError(
                             f"Argument #{idx} had shape {target.shape}, but got shape {source.shape}"
+                            "When using CUDAGraph, every call must be done with exactly the same shapes. "
+                            "Feel free to deactivate with the env variable NO_CUDA_GRAPH=1, or the decorator "
+                            "`with no_cuda_graph():`"
                         )
                     target.copy_(source)
                 else:

--- a/scripts/moshi_benchmark.py
+++ b/scripts/moshi_benchmark.py
@@ -6,9 +6,7 @@ import argparse
 import random
 import time
 
-from huggingface_hub import hf_hub_download
 import numpy as np
-import sentencepiece
 import sphn
 import torch
 from torch.profiler import profile, ProfilerActivity
@@ -18,20 +16,16 @@ from moshi.models import loaders, LMGen
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--tokenizer", type=str, help="Path to a local tokenizer file.")
-parser.add_argument(
-    "--moshi-weight", type=str, help="Path to a local checkpoint file for Moshi."
-)
-parser.add_argument(
-    "--mimi-weight", type=str, help="Path to a local checkpoint file for Mimi."
-)
-parser.add_argument(
-    "--hf-repo",
-    type=str,
-    default=loaders.DEFAULT_REPO,
-    help="HF repo to look into, defaults Moshiko. "
-    "Use this to select a different pre-trained model.",
-)
+parser.add_argument("--moshi-weight", type=str, help="Path to a local checkpoint file for Moshi.")
+parser.add_argument("--mimi-weight", type=str, help="Path to a local checkpoint file for Mimi.")
+parser.add_argument("--hf-repo", type=str, default=loaders.DEFAULT_REPO,
+                    help="HF repo to look into, defaults Moshiko. "
+                         "Use this to select a different pre-trained model.")
+parser.add_argument("--lora-weight", type=str, help="Path to a local checkpoint file for LoRA.", default=None)
+parser.add_argument("--config-path", type=str, help="Path to a local config file.", default=None)
 parser.add_argument("--steps", default=100, type=int)
+parser.add_argument("--no_fuse_lora", action="store_false", dest="fuse_lora", default=True,
+                    help="Do not fuse LoRA layers intot Linear layers.")
 parser.add_argument("--profile", action="store_true")
 parser.add_argument("--device", type=str, default="cuda")
 args = parser.parse_args()
@@ -50,23 +44,20 @@ def seed_all(seed):
 
 seed_all(42424242)
 
-if args.tokenizer is None:
-    args.tokenizer = hf_hub_download(args.hf_repo, loaders.TEXT_TOKENIZER_NAME)
-text_tokenizer = sentencepiece.SentencePieceProcessor(args.tokenizer)  # type: ignore
-
+print("retrieving checkpoint")
+checkpoint_info = loaders.CheckpointInfo.from_hf_repo(
+    args.hf_repo, args.moshi_weight, args.mimi_weight, args.tokenizer,
+    lora_weights=args.lora_weight, config_path=args.config_path)
 print("loading mimi")
-if args.mimi_weight is None:
-    args.mimi_weight = hf_hub_download(args.hf_repo, loaders.MIMI_NAME)
-mimi = loaders.get_mimi(args.mimi_weight, args.device)
+mimi = checkpoint_info.get_mimi(device=args.device)
 print("mimi loaded")
 
-print("loading moshi")
-if args.moshi_weight is None:
-    args.moshi_weight = hf_hub_download(args.hf_repo, loaders.MOSHI_NAME)
-lm = loaders.get_moshi_lm(args.moshi_weight, args.device)
-lm_gen = LMGen(lm)
-print("lm loaded")
+text_tokenizer = checkpoint_info.get_text_tokenizer()
 
+print("loading moshi")
+lm = checkpoint_info.get_moshi(device=args.device, dtype=torch.bfloat16, fuse_lora=args.fuse_lora)
+lm_gen = LMGen(lm)
+print("moshi loaded")
 
 def cb(step, total):
     print(f"{step:06d} / {total:06d}", end="\r")

--- a/scripts/test_missing_data.py
+++ b/scripts/test_missing_data.py
@@ -31,7 +31,7 @@ print("Going streaming")
 with mimi.streaming(B), torch.no_grad():
     while any(remaining):
         inputs = []
-        exec_mask = torch.rand(B) < 1.
+        exec_mask = torch.rand(B) < 0.5
         offsets = []
         for b, this_remaining in enumerate(remaining):
             offset = min(total - this_remaining, total - 1)

--- a/scripts/test_missing_data.py
+++ b/scripts/test_missing_data.py
@@ -1,3 +1,5 @@
+"""Testing exec_mask feature of the streaming module, where each batch entry
+can advance at its own pace, while retaining full compat with CUDA Graph."""
 import sys
 import sphn
 import torch

--- a/scripts/test_missing_data.py
+++ b/scripts/test_missing_data.py
@@ -1,0 +1,68 @@
+import sys
+import sphn
+import torch
+
+from moshi.models import loaders
+
+device = 'cuda'
+wnp, sr = sphn.read(sys.argv[1],
+                    start_sec=0, duration_sec=8, sample_rate=24000)
+wav = torch.from_numpy(wnp)
+ci = loaders.CheckpointInfo.from_hf_repo("kyutai/moshiko-pytorch-bf16")
+mimi = ci.get_mimi(device=device)
+mimi.eval()
+
+frame = int(mimi.sample_rate / mimi.frame_rate)
+
+total = wav.shape[-1] // frame
+B = 4
+wav = wav[..., :total * frame][None]
+remaining = [total for _ in range(B)]
+
+print("Ref computation")
+with torch.no_grad():
+    ref_codes = mimi.encode(wav[:1].to(device=device))
+    ref_audio = mimi.decode(ref_codes[:1].to(device=device))
+
+out_audio = torch.zeros_like(ref_audio.expand(B, -1, -1))
+out_codes = torch.zeros_like(ref_codes.expand(B, -1, -1))
+
+print("Going streaming")
+with mimi.streaming(B), torch.no_grad():
+    while any(remaining):
+        inputs = []
+        exec_mask = torch.rand(B) < 1.
+        offsets = []
+        for b, this_remaining in enumerate(remaining):
+            offset = min(total - this_remaining, total - 1)
+            offsets.append(offset)
+            inputs.append(wav[0, :, offset * frame: offset * frame + frame])
+        input_ = torch.stack(inputs)
+        mimi.set_exec_mask(exec_mask)
+        codes = mimi.encode(input_.to(device=device))
+        assert codes.shape[-1] == 1, codes.shape
+        w = mimi.decode(codes)
+        assert w.shape[-1] == frame, w.shape
+        print(remaining)
+        for b, active in enumerate(exec_mask.tolist()):
+            if not active or remaining[b] == 0:
+                continue
+            remaining[b] = max(0, remaining[b] - 1)
+            offset = offsets[b]
+            out_codes[b, :, offset: offset + 1] = codes[b]
+            out_audio[b, :, offset * frame: offset * frame + frame] = w[b]
+
+print(ref_codes[0, :, -1])
+print(out_codes[0, :, -1])
+for b in range(B):
+    print((out_codes[b] != ref_codes[:1]).any(dim=0).nonzero()[:1])
+d = (out_codes[..., :1] == ref_codes[..., :1]).float().mean(dim=(1, 2))
+print(d)
+d = (out_codes[..., :2] == ref_codes[..., :2]).float().mean(dim=(1, 2))
+print(d)
+d = (out_codes[..., :10] == ref_codes[..., :10]).float().mean(dim=(1, 2))
+print(d)
+d = (out_codes == ref_codes).float().mean(dim=(1, 2))
+print(d)
+d = (out_audio - ref_audio).norm(dim=-1, p=2) / ref_audio.norm(dim=-1, p=2)
+print(d.sum(dim=1))


### PR DESCRIPTION
## Checklist

- [x ] Read CONTRIBUTING.md, and accept the CLA by including the provided snippet. We will not accept PR without this.
- [ x] Run pre-commit hook.
- [x ] If you changed Rust code, run `cargo check`, `cargo clippy`, `cargo test`.

## PR Description

Add execution masks + some refactoring allowing for Convs to be CUDA Graphed.
What we are losing is the ability to pass in arbitrary amount of audio, now the end user is responsible for buffering. When running on CUDA, with CUDAGraph activated ( the default), one should also always pass the same amount of audio.