### PR TITLE
Fix moshi run_inference with the new import_torch

### DIFF
--- a/moshi/moshi/run_inference.py
+++ b/moshi/moshi/run_inference.py
@@ -34,7 +34,7 @@ def seed_all(seed):
 
 def get_condition_tensors(model_type: str, lm: LMModel, batch_size: int, cfg_coef: float) -> ConditionTensors:
     condition_tensors = {}
-    if lm.condition_provider is not None:
+    if lm.condition_provider is not None and lm.condition_provider.conditioners:
         conditions: list[ConditionAttributes] | None = None
         if model_type == 'hibiki':
             conditions = [ConditionAttributes(text={"description": "very_good"}, tensor={}) for _ in range(batch_size)]
@@ -42,8 +42,6 @@ def get_condition_tensors(model_type: str, lm: LMModel, batch_size: int, cfg_coe
                 # Extending the conditions with the negatives for the CFG.
                 conditions += [ConditionAttributes(text={"description": "very_bad"}, tensor={})
                                for _ in range(batch_size)]
-        elif model_type == 'moshi':
-            conditions = [ConditionAttributes(text={}, tensor={}) for _ in range(batch_size)]
         else:
             raise RuntimeError(f"Model expects conditioning but model type {model_type} is not supported.")
         assert conditions is not None


### PR DESCRIPTION
## Checklist

- [ ] Read CONTRIBUTING.md, and accept the CLA by including the provided snippet. We will not accept PR without this.
- [ ] Run pre-commit hook.
- [ ] If you changed Rust code, run `cargo check`, `cargo clippy`, `cargo test`.

## PR Description
When importing again some Moshi like model, we include all the time the condition provider, although empty, so extending the condition to also check if it is empty.