### PR TITLE
Fix mimi for the recent versions of MLX.

### DIFF
--- a/moshi_mlx/moshi_mlx/models/mimi.py
+++ b/moshi_mlx/moshi_mlx/models/mimi.py
@@ -9,6 +9,7 @@ from ..modules import (
     SeanetEncoder,
     SeanetDecoder,
     SplitResidualVectorQuantizer,
+    EuclideanCodebook,
     ProjectedTransformer,
     ConvDownsample1d,
     ConvTrUpsample1d,
@@ -220,4 +221,12 @@ class Mimi(nn.Module):
             if k.endswith(".convtr.weight"):
                 v = v.transpose(1, 2, 0)
             weights.append((k, v))
-        return self.load_weights(weights, strict=strict)
+        m = self.load_weights(weights, strict=strict)
+
+        def _filter_fn(module, name, _):
+            if isinstance(module, EuclideanCodebook) and name == "initialized":
+                module.update_in_place()
+            return True
+
+        m.filter_and_map(_filter_fn)
+        return m

--- a/moshi_mlx/moshi_mlx/modules/__init__.py
+++ b/moshi_mlx/moshi_mlx/modules/__init__.py
@@ -5,7 +5,7 @@
 """Modules used for building the models."""
 
 from .conv import Conv1d, ConvTranspose1d, StreamableConv1d, StreamableConvTranspose1d, NormConv1d, NormConvTranspose1d, ConvDownsample1d, ConvTrUpsample1d
-from .quantization import SplitResidualVectorQuantizer
+from .quantization import SplitResidualVectorQuantizer, EuclideanCodebook
 from .seanet import SeanetConfig, SeanetEncoder, SeanetDecoder
 from .kv_cache import KVCache, RotatingKVCache
 from .transformer import Transformer, TransformerConfig, ProjectedTransformer

--- a/moshi_mlx/moshi_mlx/modules/quantization.py
+++ b/moshi_mlx/moshi_mlx/modules/quantization.py
@@ -20,6 +20,11 @@ class EuclideanCodebook(nn.Module):
         self._embedding = self.embedding_sum / cluster_usage
         self._c2 = self._embedding.square().sum(axis=-1) / 2
 
+    def update_in_place(self):
+        cluster_usage = mx.maximum(self.cluster_usage, self._epsilon)[:, None]
+        self._embedding = self.embedding_sum / cluster_usage
+        self._c2 = self._embedding.square().sum(axis=-1) / 2
+
     def update(self, parameters: dict) -> nn.Module:
         super().update(parameters)
         cluster_usage = mx.maximum(self.cluster_usage, self._epsilon)[:, None]


### PR DESCRIPTION
In the recent versions of mlx (at least in 0.26) the update callback is not called recursively on submodules whereas this used to be the case in older versions. We relied on this to update some of the codebook parameters, instead the update is now triggered explicitely when loading the pytorch weights (the downside is that nothing will happen when loading non-pytorch weights for now).