### PR TITLE
Add softmax to extra_heads in Python implementation

### DIFF
--- a/moshi/moshi/models/lm.py
+++ b/moshi/moshi/models/lm.py
@@ -790,7 +790,7 @@ class LMGen(StreamingModule[_LMGenState]):
         if out is None:
             return None
         out, transformer_out = out
-        extra_heads = [extra_head(transformer_out) for extra_head in self.lm_model.extra_heads]
+        extra_heads = [torch.nn.functional.softmax(extra_head(transformer_out), dim=-1) for extra_head in self.lm_model.extra_heads]
         return out, extra_heads
 
     def depformer_step(


### PR DESCRIPTION
I, brandonj60, confirm that I have read and understood the terms of the CLA of Kyutai-labs, as outlined in the repository's CONTRIBUTING.md, and I agree to be bound by these terms.

## Checklist

- [ ] Read CONTRIBUTING.md, and accept the CLA by including the provided snippet. We will not accept PR without this.
- [ ] Run pre-commit hook.
- [ ] If you changed Rust code, run `cargo check`, `cargo clippy`, `cargo test`.

## PR Description
Extra_heads are currently outputting raw logits, not probabilities. Add softmax to convert to probability distribution similar to the Rust implementation.