### PR TITLE
fix bug when using a prefix in the tts

### DIFF
--- a/moshi/moshi/models/lm.py
+++ b/moshi/moshi/models/lm.py
@@ -738,13 +738,14 @@ class LMGen(StreamingModule[_LMGenState]):
             self.on_text_hook(text_token)
         if state.graphed_depth is None:
             audio_tokens = None
-        elif depformer_replace_tokens is None:
-            audio_tokens = state.graphed_depth(text_token, transformer_out)
+        else:
+            if depformer_replace_tokens is None:
+                audio_tokens = state.graphed_depth(text_token, transformer_out)
+            else:
+                assert depformer_replace_tokens.dim() == 3
+                audio_tokens = depformer_replace_tokens.squeeze(-1)
             if self.on_audio_hook is not None:
                 self.on_audio_hook(audio_tokens)
-        else:
-            assert depformer_replace_tokens.dim() == 3
-            audio_tokens = depformer_replace_tokens.squeeze(-1)
 
         state.offsets = torch.where(state.exec_mask, state.offsets + 1, state.offsets)
         state.offset_cpu += 1


### PR DESCRIPTION
… depformer

## Checklist

- [ ] Read CONTRIBUTING.md, and accept the CLA by including the provided snippet. We will not accept PR without this.
- [ ] Run pre-commit hook.
- [ ] If you changed Rust code, run `cargo check`, `cargo clippy`, `cargo test`.

## PR Description

audio_hook was not called when skipping the depformer, but the code was expecting it. seems to have been broken for a while. I figured the cleanest was to always call the hook
