### PR TITLE
Use environment variables when downloading models from Hugging Face

### DIFF
--- a/rust/moshi-backend/src/main.rs
+++ b/rust/moshi-backend/src/main.rs
@@ -127,8 +127,8 @@ async fn main() -> Result<()> {
                 standalone::download_from_hub(&mut config.stream).await?;
             }
             if !std::path::PathBuf::from(&config.static_dir).exists() {
-                use hf_hub::api::tokio::Api;
-                let api = Api::new()?;
+                use hf_hub::api::tokio::ApiBuilder;
+                let api = ApiBuilder::from_env().build().unwrap();
                 let repo = api.model("kyutai/moshi-artifacts".to_string());
                 let dist_tgz = repo.get("dist.tgz").await?;
                 if let Some(parent) = dist_tgz.parent() {

--- a/rust/moshi-backend/src/standalone.rs
+++ b/rust/moshi-backend/src/standalone.rs
@@ -110,8 +110,8 @@ pub async fn stream_handler(
 }
 
 pub async fn download_from_hub(config: &mut stream_both::Config) -> Result<()> {
-    use hf_hub::api::tokio::Api;
-    let api = Api::new()?;
+    use hf_hub::api::tokio::ApiBuilder;
+    let api = ApiBuilder::from_env().build().unwrap();
     let repo = api.model(config.hf_repo.clone());
     let extract_filename = |path: &str| -> Result<String> {
         Path::new(path)

--- a/rust/moshi-server/src/utils.rs
+++ b/rust/moshi-server/src/utils.rs
@@ -54,7 +54,7 @@ pub fn resolve_or_download(input: &str) -> Result<String> {
             }
             let repo = format!("{}/{}", s[0], s[1]);
             let file = s[2..].join("/");
-            let api = hf_hub::api::sync::Api::new()?.model(repo);
+            let api = hf_hub::api::sync::ApiBuilder::from_env().build().unwrap().model(repo);
             api.get(&file)?.to_string_lossy().to_string()
         }
     };


### PR DESCRIPTION
This PR updates all instances where the hf_hub client is initialized to use `ApiBuilder::from_env()` instead of `Api::new()`. This ensures that environment variables such as HF_HOME are respected if they exist, rather than use the default behaviour of downloading models to `~/.cache/huggingface`.

## Checklist

- [x] Read CONTRIBUTING.md, and accept the CLA by including the provided snippet. We will not accept PR without this.
- [x] Run pre-commit hook.
- [x] If you changed Rust code, run `cargo check`, `cargo clippy`, `cargo test`.

I, lucky-bai, confirm that I have read and understood the terms of the CLA of Kyutai-labs, as outlined in the repository's CONTRIBUTING.md, and I agree to be bound by these terms.
