### PR TITLE
Use torch.compile for the rms-norm.

### DIFF
--- a/moshi/moshi/modules/transformer.py
+++ b/moshi/moshi/modules/transformer.py
@@ -16,7 +16,7 @@ from einops import rearrange
 import torch
 import torch.nn as nn
 from torch.nn import functional as F
-from ..utils.compile import no_compile
+from ..utils.compile import no_compile, torch_compile_lazy
 from ..utils import quantize
 from ..utils.quantize import replace_linear_with_qlinear
 from .gating import make_gating
@@ -33,6 +33,7 @@ class LayerNormF32(nn.LayerNorm):
         return out_f32.to(input.dtype)
 
 
+@torch_compile_lazy
 def _rms_norm(
     x: torch.Tensor,
     alpha: torch.Tensor,


### PR DESCRIPTION
This seems to bring some significant speedup on the depformer part.
When using the TTS, a step goes from 19.5ms to 16.7ms on a RTX 4080 super.
