### PR TITLE
add support for `pcm16le=true` in `asr-streaming` endpoint

### DIFF
--- a/rust/moshi-server/src/main.rs
+++ b/rust/moshi-server/src/main.rs
@@ -780,6 +780,8 @@ async fn modules_info(
 #[derive(serde::Deserialize, serde::Serialize, Debug, Clone)]
 struct AsrStreamingQuery {
     auth_id: Option<String>,
+    #[serde(default)]
+    pcm16le: bool,
 }
 
 #[derive(serde::Deserialize, serde::Serialize, Debug, Clone)]
@@ -794,6 +796,8 @@ struct PyStreamingQuery {
 #[derive(serde::Deserialize, serde::Serialize, Debug, Clone)]
 struct PyAsrStreamingQuery {
     auth_id: Option<String>,
+    #[serde(default)]
+    pcm16le: bool,
 }
 
 fn asr_router(s: Arc<asr::Asr>, path: &str, ss: &SharedState) -> axum::Router<()> {

--- a/rust/moshi-server/src/py_basr_module.rs
+++ b/rust/moshi-server/src/py_basr_module.rs
@@ -558,6 +558,7 @@ impl M {
         };
         tracing::info!(?bidx, "batched-py channel");
         in_tx.send(InMsg::Init)?;
+        let expect_pcm16le = query.pcm16le;
         let recv_loop = task::spawn(async move {
             // There are two timeouts here:
             // - The short timeout handles the case where the client does not answer the regular pings.
@@ -589,7 +590,7 @@ impl M {
                     Message::Close(_) => break,
                 };
                 last_message_received = std::time::Instant::now();
-                let msg: InMsg = rmp_serde::from_slice(&msg)?;
+                let msg = InMsg::from_ws_payload(&msg, expect_pcm16le)?;
                 in_tx.send(msg)?;
             }
             Ok::<_, anyhow::Error>(())


### PR DESCRIPTION
## Checklist

- [x] Read CONTRIBUTING.md, and accept the CLA by including the provided snippet. We will not accept PR without this.
- [x] Run pre-commit hook.
- [x] If you changed Rust code, run `cargo check`, `cargo clippy`, `cargo test`.

## PR Description

Add asr-streaming query param to pass `pcm` audio instead of `msgpack`
`/api/asr-streaming?pcm16le=true`