### PR TITLE
TTS: Fix Windows compatiblity

### DIFF
--- a/rust/moshi-server/tts.py
+++ b/rust/moshi-server/tts.py
@@ -122,12 +122,17 @@ def init(batch_size: int, config_override: dict) -> 'TTSService':
         for file in voice_folder.glob(f'**/*{voice_suffix}'):
             relative = file.relative_to(voice_folder)
             name = str(relative.with_name(relative.name.removesuffix(voice_suffix)))
+            # Normalize path separators for Windows compatibility
+            name_normalized = name.replace('\\', '/')
             try:
                 attributes = tts_model.make_condition_attributes([file, file], cfg_coef=cfg_condition)
             except Exception:
-                print(f"[WARNING] failed to load voice {name}")
+                print(f"[WARNING] failed to load voice {name_normalized}")
             else:
                 all_attributes[name] = attributes
+                # Also add with forward slashes for cross-platform config compatibility
+                if name != name_normalized:
+                    all_attributes[name_normalized] = attributes
 
         if not all_attributes:
             raise RuntimeError(


### PR DESCRIPTION
## Checklist

- [x] Read CONTRIBUTING.md, and accept the CLA by including the provided snippet. We will not accept PR without this.
- [x] Run pre-commit hook.
- [ ] If you changed Rust code, run `cargo check`, `cargo clippy`, `cargo test`.

## PR Description

Windows uses backslash for path separator so tts won't be able to load the model.

This PR allow to run tts server on Windows (you will need to install `triton` and have MSVS on your `$env:PATH`, something like this)

```pwsh
$env:PATH = $env:PATH + ";C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC\14.44.35207\bin\Hostx64\x64"
```

Then you can start the tts from unmute 

```pwsh
$PYTHONHOME = uv run --no-sync --locked --project ./dockerless python -c "import sys; print(sys.base_prefix)"
$env:PATH = $env:PATH + ";$PYTHONHOME"

$env:PYTHONPATH = uv run --no-sync --locked --project ./dockerless python -c "import site; print(site.getsitepackages()[1])" # first el. is the .venv

uv run --no-sync --locked --project ./dockerless ..\moshi\rust\target\debug\moshi-server.exe worker --config services/moshi-server/configs/tts.toml --port 8089
```