### PR TITLE
Security: Unsafe deserialization of untrusted checkpoint via `torch.load`

### DIFF
--- a/scripts/import_lightformer.py
+++ b/scripts/import_lightformer.py
@@ -16,7 +16,7 @@ def import_model(
     in_path: str,
     out_path: str,
 ) -> None:
-    pkg = torch.load(in_path, map_location=torch.device("cpu"))
+    pkg = torch.load(in_path, map_location=torch.device("cpu"), weights_only=True)
     if 'xp.cfg' in pkg:
         cfg = pkg['xp.cfg']
     else:

--- a/scripts/import_mimi_pytorch.py
+++ b/scripts/import_mimi_pytorch.py
@@ -20,7 +20,7 @@ def import_model(
     args.out_folder.mkdir(exist_ok=True, parents=True)
     out_config = args.out_folder / 'mimi_config.json'
     out_file = args.out_folder / 'mimi.safetensors'
-    pkg = torch.load(args.checkpoint, map_location=torch.device("cpu"), weights_only=False)
+    pkg = torch.load(args.checkpoint, map_location=torch.device("cpu"), weights_only=True)
     if 'xp.cfg' in pkg:
         cfg = pkg['xp.cfg']
     else:


### PR DESCRIPTION
## Problem

The script loads a user-supplied checkpoint with `torch.load(..., weights_only=False)`. PyTorch pickle deserialization can execute arbitrary code during load, so running this on an untrusted file can lead to code execution on the host.

**Severity**: `high`
**File**: `scripts/import_mimi_pytorch.py`

## Solution

Treat checkpoints as untrusted input: prefer `safetensors`, or use `torch.load(..., weights_only=True)` where possible. Enforce provenance checks (hash/signature) before loading.

## Changes

- `scripts/import_mimi_pytorch.py` (modified)
- `scripts/import_lightformer.py` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
