### PR TITLE
[Fix] SeanetResnetBlock.reset_state doesn't reset StreamingAdd, breaking multi-call decode (#407)

### DIFF
--- a/moshi_mlx/moshi_mlx/modules/seanet.py
+++ b/moshi_mlx/moshi_mlx/modules/seanet.py
@@ -32,6 +32,10 @@ class StreamingAdd(nn.Module):
         self._lhs = None
         self._rhs = None
 
+    def reset_state(self):
+        self._lhs = None
+        self._rhs = None
+
     def step(self, lhs: mx.array, rhs: mx.array) -> mx.array:
         if self._lhs is not None:
             lhs = mx.concat([self._lhs, lhs], axis=-1)
@@ -94,6 +98,7 @@ class SeanetResnetBlock(nn.Module):
             self.shortcut.reset_state()
         for b in self.block:
             b.reset_state()
+        self.streaming_add.reset_state()
 
     def __call__(self, xs: mx.array) -> mx.array:
         residual = xs


### PR DESCRIPTION
## Motivation

In `moshi_mlx`, repeated streaming decode calls produce corrupted output because `SeanetResnetBlock.reset_state()` does not reset the block's `StreamingAdd` (#407).

## Root cause

`SeanetResnetBlock.reset_state()` resets the shortcut and the sub-blocks:

```python
def reset_state(self):
    if self.shortcut is not None:
        self.shortcut.reset_state()
    for b in self.block:
        b.reset_state()
```

but never resets `self.streaming_add`. `StreamingAdd` carries `_lhs`/`_rhs` residual buffers across `step()` calls, so after the first streaming decode those stale buffers leak into the next decode, corrupting the result.

## Modifications

`moshi_mlx/moshi_mlx/modules/seanet.py`: add a `reset_state()` method to `StreamingAdd` (clears `_lhs`/`_rhs`) and call it from `SeanetResnetBlock.reset_state()`, consistent with how the block resets its other stateful submodules.

## Duplicate-check

- Track A — `gh api 'repos/kyutai-labs/moshi/pulls?state=open&per_page=100' --paginate` grepped for `407` → no open PR references it.
- Track B — issue #407 has no in-progress claim.
